### PR TITLE
Hotfixes for various plotting functions

### DIFF
--- a/R/comp_report.R
+++ b/R/comp_report.R
@@ -79,17 +79,13 @@ comp_report = function(this_sample_id,
     maf = assign_cn_to_ssm(
       this_sample_id = this_sample_id,
       coding_only = FALSE,
-      from_flatfile = TRUE,
-      use_augmented_maf = TRUE,
       this_seq_type = this_seq_type)$maf
   }
 
   if(missing(seq_data) && is.null(seq_path)){
     seq = get_sample_cn_segments(
-      this_sample_id = this_sample_id,
-      multiple_samples = FALSE,
+      these_sample_ids = this_sample_id,
       streamlined = FALSE,
-      from_flatfile = TRUE,
       this_seq_type = this_seq_type
     )
   }

--- a/R/fancy_propcov_plot.R
+++ b/R/fancy_propcov_plot.R
@@ -81,7 +81,7 @@ fancy_propcov_plot = function(these_sample_ids,
 
   #retrieve data for comparison, provided as a df with sample IDs in the first column (subset from gambl metadata)
   if(!missing(comparison_samples)){
-    comp_data = collate_qc_results(sample_table = comparison_samples, seq_type_filter = seq_type) %>%
+    comp_data = collate_results(sample_table = comparison_samples, seq_type_filter = seq_type) %>%
       dplyr::select(ProportionCoverage10x, ProportionCoverage30x) %>%
       gather(Type, Value)
 

--- a/R/heatmap_mutation_frequency_bin.R
+++ b/R/heatmap_mutation_frequency_bin.R
@@ -123,13 +123,13 @@ heatmap_mutation_frequency_bin <- function(
   regions <- regions$regions_list
 
   # Harmonize metadata and sample IDs
-  get_meta <- id_ease(
+  metadata <- id_ease(
     these_samples_metadata,
     these_sample_ids,
     this_seq_type
   )
-  metadata <- get_meta$this_metadata
-  these_sample_ids <- get_meta$these_samples
+
+  these_sample_ids <- metadata$sample_id
 
   # Ensure all requested metadata columns are present in the metadata
   allMetaCols <- unique(c(metadataColumns, sortByColumns, expressionColumns))


### PR DESCRIPTION
This PR addresses a few things:

1. The internal call of `assign_cn_to_ssm` in `comp_report.R` calls `GAMBLR.results` exclusive parameters, causing issues when a non-GSC user runs this function with `GAMBLR.data` as their only way of retrieving data (i.e calling `assign_cnm_to_ssm`) (issue #8).
2. In `fancy_propcov_plot`, if the user does not provide a data frame with collated results (QC metrics) for comparison values the function inaccurately calls `collate_qc_results`, this has been updated to properly call `collate_results` instead.
3. Lingering issue with `heatmap_mutation_frequency_bin.R` that wrongly expects `id_ease` to return a list with metadata and sample IDs as its objects. This has been updated to behave in the expected way. 