### PR TITLE
more options in prettyOncoplot

### DIFF
--- a/R/prettyOncoplot.R
+++ b/R/prettyOncoplot.R
@@ -214,6 +214,7 @@ prettyOncoplot = function(
     split_columns_kmeans,
     dry_run = FALSE,
     simplify_annotation= FALSE,
+    simlify_bg_colour = NA,
     stacked = FALSE,
     numeric_heatmap_type = "aSHM",
     numeric_heatmap_location = "top",
@@ -616,7 +617,7 @@ prettyOncoplot = function(
 
         alter_fun = list(
         background = function(x, y, w, h) grid.rect(x, y, w, h,
-                                                    gp = gpar(fill = NA,col=NA)),
+                                                    gp = gpar(fill = simlify_bg_colour,col=NA)),
 
         Missense = function(x, y, w, h){ grid.rect(x, y, w*0.9, h*0.9,
                                                 gp = gpar(fill = col["Missense"], col = NA))},

--- a/R/prettyOncoplot.R
+++ b/R/prettyOncoplot.R
@@ -62,6 +62,7 @@
 #' @param split_columns_kmeans K value for k-means clustering on columns
 #' @param dry_run Set to TRUE to more efficiently view the clustering result while debugging cluster_rows/clustering_distance_rows
 #' @param simplify_annotation Collapse/group the variant effect categories to only 3 options. This is a much faster option for when many patients/genes are included.
+#' @param simlify_bg_colour When simplify_annotation is called, adjust the color of the background by passign a value to this argument. Default is NA.
 #' @param stacked Create a dual heatmap with the second (lower) portion for the numeric metadata provided (e.g. aSHM)
 #' @param numeric_heatmap_type Which type of numeric heatmap to draw? Accepts either "aSHM" (default) or "CNV".
 #' @param numeric_heatmap_location Where to draw the numeric heatmap. Can be "top" (default) or "bottom".

--- a/R/prettyOncoplot.R
+++ b/R/prettyOncoplot.R
@@ -62,7 +62,7 @@
 #' @param split_columns_kmeans K value for k-means clustering on columns
 #' @param dry_run Set to TRUE to more efficiently view the clustering result while debugging cluster_rows/clustering_distance_rows
 #' @param simplify_annotation Collapse/group the variant effect categories to only 3 options. This is a much faster option for when many patients/genes are included.
-#' @param simlify_bg_colour When simplify_annotation is called, adjust the color of the background by passign a value to this argument. Default is NA.
+#' @param simplify_bg_colour When simplify_annotation is called, adjust the color of the background by passign a value to this argument. Default is NA.
 #' @param stacked Create a dual heatmap with the second (lower) portion for the numeric metadata provided (e.g. aSHM)
 #' @param numeric_heatmap_type Which type of numeric heatmap to draw? Accepts either "aSHM" (default) or "CNV".
 #' @param numeric_heatmap_location Where to draw the numeric heatmap. Can be "top" (default) or "bottom".
@@ -215,7 +215,7 @@ prettyOncoplot = function(
     split_columns_kmeans,
     dry_run = FALSE,
     simplify_annotation= FALSE,
-    simlify_bg_colour = NA,
+    simplify_bg_colour = NA,
     stacked = FALSE,
     numeric_heatmap_type = "aSHM",
     numeric_heatmap_location = "top",
@@ -618,7 +618,7 @@ prettyOncoplot = function(
 
         alter_fun = list(
         background = function(x, y, w, h) grid.rect(x, y, w, h,
-                                                    gp = gpar(fill = simlify_bg_colour,col=NA)),
+                                                    gp = gpar(fill = simplify_bg_colour,col=NA)),
 
         Missense = function(x, y, w, h){ grid.rect(x, y, w*0.9, h*0.9,
                                                 gp = gpar(fill = col["Missense"], col = NA))},

--- a/man/prettyOncoplot.Rd
+++ b/man/prettyOncoplot.Rd
@@ -178,6 +178,8 @@ prettyOncoplot(
 
 \item{simplify_annotation}{Collapse/group the variant effect categories to only 3 options. This is a much faster option for when many patients/genes are included.}
 
+\item{simlify_bg_colour}{When simplify_annotation is called, adjust the color of the background by passign a value to this argument. Default is NA.}
+
 \item{stacked}{Create a dual heatmap with the second (lower) portion for the numeric metadata provided (e.g. aSHM)}
 
 \item{numeric_heatmap_type}{Which type of numeric heatmap to draw? Accepts either "aSHM" (default) or "CNV".}

--- a/man/prettyOncoplot.Rd
+++ b/man/prettyOncoplot.Rd
@@ -60,7 +60,7 @@ prettyOncoplot(
   split_columns_kmeans,
   dry_run = FALSE,
   simplify_annotation = FALSE,
-  simlify_bg_colour = NA,
+  simplify_bg_colour = NA,
   stacked = FALSE,
   numeric_heatmap_type = "aSHM",
   numeric_heatmap_location = "top",
@@ -178,7 +178,7 @@ prettyOncoplot(
 
 \item{simplify_annotation}{Collapse/group the variant effect categories to only 3 options. This is a much faster option for when many patients/genes are included.}
 
-\item{simlify_bg_colour}{When simplify_annotation is called, adjust the color of the background by passign a value to this argument. Default is NA.}
+\item{simplify_bg_colour}{When simplify_annotation is called, adjust the color of the background by passign a value to this argument. Default is NA.}
 
 \item{stacked}{Create a dual heatmap with the second (lower) portion for the numeric metadata provided (e.g. aSHM)}
 

--- a/man/prettyOncoplot.Rd
+++ b/man/prettyOncoplot.Rd
@@ -60,6 +60,7 @@ prettyOncoplot(
   split_columns_kmeans,
   dry_run = FALSE,
   simplify_annotation = FALSE,
+  simlify_bg_colour = NA,
   stacked = FALSE,
   numeric_heatmap_type = "aSHM",
   numeric_heatmap_location = "top",


### PR DESCRIPTION
The simplify_annotation sometimes would create a plot with a black background. This update preserves the current behavior while allowing the user to set the desired color for the background through the new argument `simplify_bg_colour`