### PR TITLE
Fix prettyOncoplot

### DIFF
--- a/R/ashm_multi_rainbow_plot.R
+++ b/R/ashm_multi_rainbow_plot.R
@@ -54,6 +54,10 @@ ashm_multi_rainbow_plot = function(regions_bed,
   
   #get the mutations for each region and combine
   #regions_bed should contain chr, start, end, name (with these exact names)
+  if("maf_data" %in% class(maf_df)){
+        #drop our S3 classes because these additional attributes seem to cause some problems when the data is subsequently munged.
+        maf_df = strip_genomic_classes(maf_df)
+  }
   if(missing(metadata)){
     metadata = get_gambl_metadata(seq_type_filter = this_seq_type)
     meta_arranged = arrange(metadata, pathology_rank, lymphgen)

--- a/R/heatmap_mutation_frequency_bin.R
+++ b/R/heatmap_mutation_frequency_bin.R
@@ -47,7 +47,7 @@
 #'
 #' @return A table of mutation counts for sliding windows across one or more regions. May be long or wide.
 #'
-#' @import dplyr tidyr tibble ComplexHeatmap circlize grid
+#' @import dplyr tidyr tibble ComplexHeatmap circlize grid parallel
 #' @export
 #'
 #' @examples
@@ -79,7 +79,7 @@ heatmap_mutation_frequency_bin <- function(regions_list = NULL,
                                            this_seq_type = c("genome", "capture"),
                                            maf_data,
                                            mut_freq_matrix,
-                                           projection = "grch37",
+                                           projection,
                                            region_padding = 1000,
                                            drop_unmutated = FALSE,
                                            metadataColumns = c("pathology"),
@@ -110,6 +110,34 @@ heatmap_mutation_frequency_bin <- function(regions_list = NULL,
                                            return_heatmap_obj = FALSE,
                                            from_indexed_flatfile = TRUE,
                                            mode = "slms-3") {
+  #this could definitely use a helper function that takes all arguments that can be a genome_bed type
+  if(missing(projection)){
+    if(!missing(regions_bed) & !missing(maf_data)){
+      if("genomic_data" %in% class(regions_bed) & "genomic_data" %in% class(maf_data)){
+        if(!get_genome_build(regions_bed)==get_genome_build(maf_data)){
+          stop("The genome build of the regions_bed and maf_data are different. Supply a regions_bed that matches the genome_build of maf_df!")
+        }
+        projection = get_genome_build(regions_bed)
+      }else{
+        if("genomic_data" %in% class(regions_bed)){
+          projection = get_genome_build(regions_bed)
+        }else if("genomic_data" %in% class(maf_data)){
+          projection = get_genome_build(maf_data)
+        }
+      }
+    }else if(!missing(regions_bed)){
+      if("genomic_data" %in% class(regions_bed)){
+        projection = get_genome_build(regions_bed)
+      }
+    }else if(!missing(regions_maf)){
+      if("genomic_data" %in% class(regions_bed)){
+        projection = get_genome_build(regions_bed)
+      }
+    }
+  }
+  if(missing(projection)){
+    stop("projection is missing and cannot be inferred from supplied arguments")
+  }
   # check arguments
   stopifnot(
     "Only one (or none) between regions_list and regions_bed arguments should be provided." =
@@ -133,12 +161,10 @@ heatmap_mutation_frequency_bin <- function(regions_list = NULL,
   regions_bed <- regions$regions_bed
   regions <- regions$regions_list
 
-  # Harmonize metadata and sample IDs
-  metadata <- id_ease(
-    these_samples_metadata,
-    these_sample_ids,
-    this_seq_type
-  )
+  if(missing(these_samples_metadata)){
+    stop("these_samples_metadata is required")
+  }
+  metadata = these_samples_metadata
 
   these_sample_ids <- metadata$sample_id
 
@@ -166,19 +192,21 @@ heatmap_mutation_frequency_bin <- function(regions_list = NULL,
     # Obtain sliding window mutation frequencies for all regions
     if (missing(maf_data)) {
       maf_data <- NULL
+    }else{
+      if("genomic_data" %in% class(maf_data)){
+        maf_data = strip_genomic_classes(maf_data)
+      }
     }
 
     all_wide <- calc_mutation_frequency_bin_regions(
-      maf_data = maf_data,
+      #maf_data = maf_data,
       regions_bed = regions_bed,
       these_samples_metadata = metadata,
       projection = projection,
       slide_by = slide_by,
       window_size = window_size,
       drop_unmutated = drop_unmutated,
-      return_format = "wide",
-      from_indexed_flatfile = from_indexed_flatfile,
-      mode = mode
+      return_format = "wide"
     )
 
     # Convert to a matrix with samples in colnames and bins in rownames

--- a/R/pretty_CN_heatmap.R
+++ b/R/pretty_CN_heatmap.R
@@ -28,7 +28,7 @@
 #' @param show_bottom_annotation_name set to TRUE to label the bottom annotation tracks with more details
 #' @param bottom_annotation_name_side If using show_bottom_annotation_name, set this to "left" or "right" to relocate the names
 #' @param bin_labels Instead of automatically labeling genes, you can instead explicitly provide a list of labels for any bins in the heatmap. The names of each element should match a bin. The value of each element is the label that will be shown. This option can be used to skip gene location look-ups (see examples).
-#' @param focus_on_these_bins Mask all regions outside these bins (set CN to 0). Useful for visualizing GISTIC results. 
+#' @param focus_on_these_bins Mask all regions outside these bins (set CN to 0). Useful for visualizing GISTIC results.
 #' @param legend_direction Which orientation to use for the legend
 #' @param legend_position Where to put the legend
 #' @param legend_row How many rows for the legend layout
@@ -53,14 +53,15 @@
 #'
 #' # Create the copy number matrix using the helper functions
 #' all_segments = get_cn_segments()
-#' all_states_binned = get_cn_states(n_bins_split=2500,
-#'                                  missing_data_as_diploid = T,
-#'                                  seg_data = all_segments,
-#'                                  these_samples_metadata = dlbcl_genome_meta)
-#'
+#' dlbcl_cn_binned = segmented_data_to_cn_matrix(
+#'                                   seg_data = all_segments,
+#'                                   strategy="auto_split",
+#'                                   n_bins_split=2500,
+#'                                   missing_data_as_diploid = T,
+#'                                   these_samples_metadata = dlbcl_genome_meta)
 #'
 #' # Generate a basic genome-wide CN heatmap
-#' pretty_CN_heatmap(cn_state_matrix=all_states_binned,
+#' pretty_CN_heatmap(cn_state_matrix=dlbcl_cn_binned,
 #'                   these_samples_metadata = dlbcl_genome_meta,
 #'                   hide_annotations = "chromosome")
 #'
@@ -182,7 +183,7 @@ pretty_CN_heatmap = function(cn_state_matrix,
   if(missing(bin_labels)){
     bin_labels = list()
   }
-  
+
   if(!missing(geneBoxPlot)){
     if(missing(labelTheseGenes)){
       labelTheseGenes = geneBoxPlot
@@ -284,7 +285,8 @@ pretty_CN_heatmap = function(cn_state_matrix,
                 "chr20"="#AF2064",
                 "chr21"="#E6C66F",
                 "chr22"="#5B665D",
-                "chrX"="#CA992C")
+                "chrX"="#CA992C",
+                "chrY"="white")
 
   #assume format is chrX:XXX-XXX
   column_chromosome = str_remove(colnames(cn_state_matrix),":.+")
@@ -296,6 +298,11 @@ pretty_CN_heatmap = function(cn_state_matrix,
     column_chromosome = column_chromosome[keep_cols]
 
   }
+  if(!grepl("chr",column_chromosome[1])){
+    #remove chr prefix from colours
+    names(chrom_col) = str_remove(names(chrom_col),"chr")
+  }
+  print(chrom_col)
   splits = NULL
   if(!missing(sortByBins)){
     cluster_rows = FALSE
@@ -562,7 +569,7 @@ pretty_CN_heatmap = function(cn_state_matrix,
   }
 
   draw(ho,heatmap_legend_side=legend_position,annotation_legend_side=legend_position)
-  if(!missing(labelTheseGenes)|!missing(bin_labels)){
+  if(!missing(labelTheseGenes)|length(bin_labels)>0){
     for(i in c(1:length(bin_labels))){
         gene_region = names(bin_labels)[i]
         gene_name = unname(bin_labels[[i]])
@@ -582,6 +589,9 @@ pretty_CN_heatmap = function(cn_state_matrix,
   }
 
   if(return_data){
+    if(length(bin_labels)==0){
+      bin_labels=NULL
+    }
     return(list(heatmap_object=ho,
                 data=cn_state_matrix,
                 cumulative_gain = total_gain,

--- a/R/pretty_CN_heatmap.R
+++ b/R/pretty_CN_heatmap.R
@@ -302,7 +302,7 @@ pretty_CN_heatmap = function(cn_state_matrix,
     #remove chr prefix from colours
     names(chrom_col) = str_remove(names(chrom_col),"chr")
   }
-  print(chrom_col)
+
   splits = NULL
   if(!missing(sortByBins)){
     cluster_rows = FALSE

--- a/man/pretty_CN_heatmap.Rd
+++ b/man/pretty_CN_heatmap.Rd
@@ -25,8 +25,10 @@ pretty_CN_heatmap(
   labelTheseGenes,
   bin_label_fontsize = 5,
   bin_label_nudge = 1.03,
+  bin_label_rotation = 45,
   drop_if_PGA_below = 0,
   drop_if_PGA_above = 1,
+  focus_on_these_bins,
   geneBoxPlot,
   show_bottom_annotation_name = FALSE,
   bottom_annotation_name_side = "left",
@@ -88,6 +90,8 @@ pretty_CN_heatmap(
 
 \item{drop_if_PGA_above}{Upper limit for proportion of genome altered (PGA). Samples above this value will be dropped (default 1)}
 
+\item{focus_on_these_bins}{Mask all regions outside these bins (set CN to 0). Useful for visualizing GISTIC results.}
+
 \item{geneBoxPlot}{Optional: Specify the Hugo symbol of a single gene to embed box plots adjacent to the heatmap. Expression data for this gene must be present in the metadata in a column of the same name.}
 
 \item{show_bottom_annotation_name}{set to TRUE to label the bottom annotation tracks with more details}
@@ -132,14 +136,15 @@ dlbcl_genome_meta = get_gambl_metadata() \%>\%
 
 # Create the copy number matrix using the helper functions
 all_segments = get_cn_segments()
-all_states_binned = get_cn_states(n_bins_split=2500,
-                                 missing_data_as_diploid = T,
-                                 seg_data = all_segments,
-                                 these_samples_metadata = dlbcl_genome_meta)
-
+dlbcl_cn_binned = segmented_data_to_cn_matrix(
+                                  seg_data = all_segments,
+                                  strategy="auto_split",
+                                  n_bins_split=2500,
+                                  missing_data_as_diploid = T,
+                                  these_samples_metadata = dlbcl_genome_meta)
 
 # Generate a basic genome-wide CN heatmap
-pretty_CN_heatmap(cn_state_matrix=all_states_binned,
+pretty_CN_heatmap(cn_state_matrix=dlbcl_cn_binned,
                   these_samples_metadata = dlbcl_genome_meta,
                   hide_annotations = "chromosome")
 


### PR DESCRIPTION
The new S3 classes caused an unexpected issue in prettyOncoplot. The solution is straightforward. We just need to add this at the start of any function that is affected. Since this breaks compatability between the current GAMBLR.results/GAMBLR.data and GAMBLR.viz we should assign a new version number for all GAMBLR packages that incorporate these changes. 

```
    if("maf_data" %in% class(maf_df)){
        #drop our S3 classes because these additional attributes seem to cause some problems when the data is subsequently munged.
        maf_df = strip_genomic_classes(maf_df)
    }
```