### PR TITLE
fix: prevent hotspot double counting in prettyOncoplot barplot and ordering

### DIFF
--- a/R/prettyOncoplot.R
+++ b/R/prettyOncoplot.R
@@ -1285,6 +1285,8 @@ prettyOncoplot <- function(maf_df, # nolint: object_name_linter.
         gp = gpar(fill = col["Missense_Mutation"], col = box_col)
       )
     }, hot_spot = function(x, y, w, h) {
+      grid.rect(x, y, w - unit(spacing, "pt"), h * height_scaling,
+        gp = gpar(fill = col["Missense_Mutation"], col = box_col))
       grid.rect(x, y, w - unit(spacing, "pt"), (height_scaling / 5) *
         h, gp = gpar(fill = col["hot_spot"], col = box_col))
     }, Silent = function(x, y, w, h) {
@@ -1327,11 +1329,7 @@ prettyOncoplot <- function(maf_df, # nolint: object_name_linter.
 
     for (i in colnames(mat)) {
       mat[genes_kept, i][!is.na(hot_mat[genes_kept, i])] <-
-        paste0(
-          mat[genes_kept, i][!is.na(hot_mat[genes_kept, i])],
-          ";",
-          hot_mat[genes_kept, i][!is.na(hot_mat[genes_kept, i])]
-        )
+        hot_mat[genes_kept, i][!is.na(hot_mat[genes_kept, i])]
     }
 
     if (verbose) {

--- a/R/prettyOncoplot.R
+++ b/R/prettyOncoplot.R
@@ -1285,8 +1285,6 @@ prettyOncoplot <- function(maf_df, # nolint: object_name_linter.
         gp = gpar(fill = col["Missense_Mutation"], col = box_col)
       )
     }, hot_spot = function(x, y, w, h) {
-      grid.rect(x, y, w - unit(spacing, "pt"), h * height_scaling,
-        gp = gpar(fill = col["Missense_Mutation"], col = box_col))
       grid.rect(x, y, w - unit(spacing, "pt"), (height_scaling / 5) *
         h, gp = gpar(fill = col["hot_spot"], col = box_col))
     }, Silent = function(x, y, w, h) {
@@ -1305,6 +1303,30 @@ prettyOncoplot <- function(maf_df, # nolint: object_name_linter.
     }
     if (verbose) {
       print("annotating hot spots")
+    }
+    # For non-simplify mode, generate a composite alter_fun for every existing
+    # mutation type. The composite key "<type>_hs" maps to col["hot_spot"] so
+    # the barplot counts hotspot mutations under a single magenta category, while
+    # the alter_fun draws the original type's full-height bar first and then
+    # overlays the small magenta hotspot indicator — preserving the background
+    # colour regardless of which mutation class the hotspot belongs to.
+    if (!simplify_annotation) {
+      for (type in setdiff(names(alter_fun), "background")) {
+        hs_type <- paste0(type, "_hs")
+        col[hs_type] <- col["hot_spot"]
+        local({
+          hs_t <- paste0(type, "_hs")
+          base_fun <- alter_fun[[type]]
+          alter_fun[[hs_t]] <<- function(x, y, w, h) {
+            base_fun(x, y, w, h)
+            grid.rect(
+              x, y, w - unit(spacing, "pt"),
+              (height_scaling / 5) * h,
+              gp = gpar(fill = col["hot_spot"], col = box_col)
+            )
+          }
+        })
+      }
     }
     hot_samples <- dplyr::filter(maf_df, hot_spot == TRUE &
       Hugo_Symbol %in% genes_kept) %>%
@@ -1327,9 +1349,19 @@ prettyOncoplot <- function(maf_df, # nolint: object_name_linter.
       column_to_rownames("Hugo_Symbol") %>%
       as.matrix()
 
-    for (i in colnames(mat)) {
-      mat[genes_kept, i][!is.na(hot_mat[genes_kept, i])] <-
-        hot_mat[genes_kept, i][!is.na(hot_mat[genes_kept, i])]
+    if (!simplify_annotation) {
+      # Replace non-empty hotspot cells with a composite key that encodes the
+      # original mutation type so the correct background colour is drawn.
+      # Empty cells (unmutated samples) are skipped — a hotspot annotation in
+      # the MAF without a corresponding coding mutation in the matrix has no
+      # visual representation.
+      for (i in colnames(mat)) {
+        hotspot_mask <- !is.na(hot_mat[genes_kept, i]) &
+          nzchar(mat[genes_kept, i])
+        mat[genes_kept, i][hotspot_mask] <- paste0(
+          mat[genes_kept, i][hotspot_mask], "_hs"
+        )
+      }
     }
 
     if (verbose) {


### PR DESCRIPTION
## Summary

When \`highlightHotspots = TRUE\`, hotspot mutations were appended to the oncomatrix cell as \`"Missense_Mutation;hot_spot"\`. ComplexHeatmap builds a 3D boolean array where both entries are TRUE, causing two bugs:

1. **Inflated gene ordering** — \`count_matrix\` sums all alteration types per cell, so a hotspot mutation scored 2 instead of 1, pushing hotspot-enriched genes artificially higher in the row order
2. **Inflated right-side barplot** — \`anno_oncoprint_barplot\` stacks bars per alteration type using \`sum()\`, so each hotspot mutation contributed to both its original-type bar and the \`hot_spot\` bar

Additionally, the background colour of hotspot cells was not being preserved — a truncating or splice-site hotspot would have appeared in the wrong colour.

**Fix:** for each mutation type defined in \`alter_fun\`, a composite key \`"<type>_hs"\` (e.g. \`"Missense_Mutation_hs"\`, \`"Nonsense_Mutation_hs"\`) is generated at runtime. The matrix loop appends \`"_hs"\` to the original cell value instead of appending \`";hot_spot"\`, so:

- Each hotspot mutation is counted **once** — under its composite key, not double-counted
- All \`"_hs"\` keys are mapped to \`col["hot_spot"]\` (magenta), so the barplot shows hotspot mutations as a distinct magenta category separate from non-hotspot mutations of each type
- Each composite \`alter_fun\` calls the original type's drawing function first (preserving the correct background colour for any mutation class) and then overlays the small magenta indicator
- Empty cells are skipped, so hotspot MAF entries without a corresponding coding mutation in the matrix are silently ignored
- The \`simplify_annotation = TRUE\` code path is unaffected (it handles hotspots independently via \`hotspot_df\`)

## Test plan

- [x] Run \`test_data/prettyOncoplot_test.R\` with \`highlightHotspots = TRUE\` and confirm the right-side barplot bars are no longer inflated compared to a \`highlightHotspots = FALSE\` run of the same data
- [x] Confirm gene ordering within each \`splitGeneGroup\` is consistent between \`highlightHotspots = TRUE\` and \`FALSE\`
- [x] Confirm hotspot cells display the **correct background colour** for their mutation type (e.g. red for a truncating hotspot, green for a missense hotspot) with the magenta indicator overlaid
- [x] Confirm \`highlightHotspots = FALSE\` behaviour is completely unchanged
- [x] Confirm \`simplify_annotation = TRUE\` with \`highlightHotspots = TRUE\` is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)